### PR TITLE
Relax pronto version restriction

### DIFF
--- a/pronto-tailor.gemspec
+++ b/pronto-tailor.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_runtime_dependency 'pronto', '~> 0.5.0'
+  spec.add_runtime_dependency 'pronto', '~> 0.5'
   spec.add_development_dependency 'rspec', '~> 3.3'
 end


### PR DESCRIPTION
There isn't really a need to lock to a minor pronto version, and when using many pronto support gems, the chances of updating when one moves to a new minor version of pronto become very small. 
